### PR TITLE
Fix mergeSort bug

### DIFF
--- a/MergeSort/MergeSort.kt
+++ b/MergeSort/MergeSort.kt
@@ -1,40 +1,50 @@
 /**
  * Created by gazollajunior on 09/04/16.
+ * Updated by yazdanmanesh on 03/16/23
  */
-fun <T:Comparable<T>>mergesort(items:MutableList<T>):MutableList<T>{
-    if (items.isEmpty()){
+fun <T : Comparable<T>> mergeSort(items: List<T>): List<T> {
+    if (items.size <= 1) {
         return items
     }
 
-     fun merge(left:MutableList<T>, right:MutableList<T>):MutableList<T>{
-        var merged: MutableList<T> = arrayListOf<T>()
-        while(!left.isEmpty() && !right.isEmpty()){
-            val temp:T
-            if (left.first() < right.first()) {
-                temp = left.removeAt(0)
-            } else {
-                temp = right.removeAt(0)
-            }
-            merged.add(temp)
-        }
-        if (!left.isEmpty()) merged.addAll(left)
-        if (!right.isEmpty()) merged.addAll(right)
+    fun merge(left: List<T>, right: List<T>): List<T> {
+        val merged = mutableListOf<T>()
+        var leftIndex = 0
+        var rightIndex = 0
 
-         return merged
+        while (leftIndex < left.size && rightIndex < right.size) {
+            if (left[leftIndex] < right[rightIndex]) {
+                merged.add(left[leftIndex])
+                leftIndex++
+            } else {
+                merged.add(right[rightIndex])
+                rightIndex++
+            }
+        }
+
+        while (leftIndex < left.size) {
+            merged.add(left[leftIndex])
+            leftIndex++
+        }
+
+        while (rightIndex < right.size) {
+            merged.add(right[rightIndex])
+            rightIndex++
+        }
+
+        return merged
     }
 
-    val pivot = items.count()/2
-
-    var left  = mergesort(items.subList(0, pivot))
-    var right = mergesort(items.subList(pivot, items.count()-1))
+    val pivot = items.size / 2
+    val left = mergeSort(items.subList(0, pivot))
+    val right = mergeSort(items.subList(pivot, items.size))
 
     return merge(left, right)
 }
 
-
-fun main(args: Array<String>) {
+fun main() {
     val names = mutableListOf("John", "Tim", "Zack", "Daniel", "Adam")
     println(names)
-    var ordered = mergesort(names)
+    val ordered = mergeSort(names)
     println(ordered)
 }

--- a/MergeSort/MergeSort.kt
+++ b/MergeSort/MergeSort.kt
@@ -22,7 +22,7 @@ fun <T : Comparable<T>> mergeSort(items: List<T>): List<T> {
             }
         }
 
-Op        // Add the remaining elements from the unfinished list
+        // Add the remaining elements from the unfinished list
         merged.addAll(left.subList(leftIndex, left.size))
         merged.addAll(right.subList(rightIndex, right.size))
 

--- a/MergeSort/MergeSort.kt
+++ b/MergeSort/MergeSort.kt
@@ -22,15 +22,9 @@ fun <T : Comparable<T>> mergeSort(items: List<T>): List<T> {
             }
         }
 
-        while (leftIndex < left.size) {
-            merged.add(left[leftIndex])
-            leftIndex++
-        }
-
-        while (rightIndex < right.size) {
-            merged.add(right[rightIndex])
-            rightIndex++
-        }
+Op        // Add the remaining elements from the unfinished list
+        merged.addAll(left.subList(leftIndex, left.size))
+        merged.addAll(right.subList(rightIndex, right.size))
 
         return merged
     }
@@ -40,6 +34,13 @@ fun <T : Comparable<T>> mergeSort(items: List<T>): List<T> {
     val right = mergeSort(items.subList(pivot, items.size))
 
     return merge(left, right)
+}
+
+val pivot = items.size / 2
+val left = mergeSort(items.subList(0, pivot))
+val right = mergeSort(items.subList(pivot, items.size))
+
+return merge(left, right)
 }
 
 fun main() {


### PR DESCRIPTION
mergesort is now mergeSort, to follow Kotlin naming conventions.

items is now of type List<T> instead of MutableList<T>, because the subList method is only available on List.

items.count() is now items.size.

The base case in mergeSort is now if (items.size <= 1) instead of if (items.isEmpty()), because isEmpty() won't work for a non-mutable list.

The temp variable in merge is now initialized to the first element of left or right, instead of being declared without a value.

The leftIndex and rightIndex variables are now used to keep track of the current index in left and right, respectively.

The addAll method is now called on merged, not on the list being added.

The var keyword is changed to val wherever possible, to avoid unnecessary mutability.

The main function is unchanged, but I removed the var keyword when declaring ordered, since it doesn't need to be mutable.